### PR TITLE
Constrain fixed-top navbar properly in Safari

### DIFF
--- a/src/bulma-dashboard.sass
+++ b/src/bulma-dashboard.sass
@@ -75,6 +75,7 @@ $dashboard-panel-footer-top-margin: 2rem !default
   
     .navbar
       &.is-fixed-top
+        position: -webkit-sticky
         position: sticky
         top: 0
 


### PR DESCRIPTION
Hi @lucperkins,

Thanks for making this extension -- filling a longstanding common need in Bulma.

I found in Safari (both MacOS and iOS) the fixed-top navbar (from the example.html) would render across the whole page obscuring elements instead of being constrained to the `dashboard-main` section. 

<img width="810" alt="screen shot 2018-12-26 at 5 39 21 am" src="https://user-images.githubusercontent.com/1711033/50445126-7fb56d80-08da-11e9-9bb5-062a05e610ad.png">

 I don't think `position: sticky` works in Safari without adding a prefix so the fix was as easy as adding `position: -webkit-sticky`... now it renders perfectly.

<img width="1143" alt="screen shot 2018-12-26 at 6 51 57 am" src="https://user-images.githubusercontent.com/1711033/50445161-c99e5380-08da-11e9-9594-00fbc1711eb5.png">
